### PR TITLE
Update Google Drive OAuth scope to include full Drive access

### DIFF
--- a/src/google-handler.ts
+++ b/src/google-handler.ts
@@ -53,7 +53,7 @@ async function redirectToGoogle(
 				clientId: c.env.GOOGLE_CLIENT_ID,
 				hostedDomain: c.env.HOSTED_DOMAIN,
 				redirectUri: new URL("/callback", c.req.raw.url).href,
-				scope: "email profile",
+				scope: "email profile https://www.googleapis.com/auth/drive",
 				state: btoa(JSON.stringify(oauthReqInfo)),
 				upstreamUrl: "https://accounts.google.com/o/oauth2/v2/auth",
 			}),

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,9 +13,15 @@ type Props = {
 };
 
 // Google Drive API Permission types
+// Using strict discriminated union for type safety
 type DrivePermission =
 	| {
-			type: "user" | "group";
+			type: "user";
+			role: "reader" | "writer" | "commenter";
+			emailAddress: string;
+	  }
+	| {
+			type: "group";
 			role: "reader" | "writer" | "commenter";
 			emailAddress: string;
 	  }
@@ -323,45 +329,47 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 				type: z.enum(["user", "group", "domain", "anyone"]).default("user").describe("Permission type"),
 			},
 			async ({ fileId, email, domain, role, type }) => {
-				// Build type-safe permission object using discriminated union
+				// Build type-safe permission object using strict discriminated union
 				let permission: DrivePermission;
 
-				if (type === "user" || type === "group") {
+				// Handle each type separately for strict type safety
+				if (type === "user") {
 					if (!email) {
 						return {
-							content: [
-								{
-									type: "text",
-									text: `Error: 'email' parameter is required for type '${type}'`,
-								},
-							],
+							content: [{ type: "text", text: "Error: 'email' parameter is required for type 'user'" }],
 						};
 					}
 					permission = {
-						type,
+						type: "user",
+						role,
+						emailAddress: email,
+					};
+				} else if (type === "group") {
+					if (!email) {
+						return {
+							content: [{ type: "text", text: "Error: 'email' parameter is required for type 'group'" }],
+						};
+					}
+					permission = {
+						type: "group",
 						role,
 						emailAddress: email,
 					};
 				} else if (type === "domain") {
 					if (!domain) {
 						return {
-							content: [
-								{
-									type: "text",
-									text: "Error: 'domain' parameter is required for type 'domain'",
-								},
-							],
+							content: [{ type: "text", text: "Error: 'domain' parameter is required for type 'domain'" }],
 						};
 					}
 					permission = {
-						type,
+						type: "domain",
 						role,
 						domain,
 					};
 				} else {
 					// type === "anyone"
 					permission = {
-						type,
+						type: "anyone",
 						role,
 					};
 				}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,23 @@ type Props = {
 	accessToken: string;
 };
 
+// Google Drive API Permission types
+type DrivePermission =
+	| {
+			type: "user" | "group";
+			role: "reader" | "writer" | "commenter";
+			emailAddress: string;
+	  }
+	| {
+			type: "domain";
+			role: "reader" | "writer" | "commenter";
+			domain: string;
+	  }
+	| {
+			type: "anyone";
+			role: "reader" | "writer" | "commenter";
+	  };
+
 export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 	server = new McpServer({
 		name: "Google Drive MCP",
@@ -306,13 +323,9 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 				type: z.enum(["user", "group", "domain", "anyone"]).default("user").describe("Permission type"),
 			},
 			async ({ fileId, email, domain, role, type }) => {
-				// Build permission object based on type
-				const permission: any = {
-					type,
-					role,
-				};
+				// Build type-safe permission object using discriminated union
+				let permission: DrivePermission;
 
-				// Add type-specific fields
 				if (type === "user" || type === "group") {
 					if (!email) {
 						return {
@@ -324,7 +337,11 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 							],
 						};
 					}
-					permission.emailAddress = email;
+					permission = {
+						type,
+						role,
+						emailAddress: email,
+					};
 				} else if (type === "domain") {
 					if (!domain) {
 						return {
@@ -336,9 +353,18 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 							],
 						};
 					}
-					permission.domain = domain;
+					permission = {
+						type,
+						role,
+						domain,
+					};
+				} else {
+					// type === "anyone"
+					permission = {
+						type,
+						role,
+					};
 				}
-				// For type 'anyone', no additional fields needed
 
 				const response = await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}/permissions`, {
 					method: "POST",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,14 +14,320 @@ type Props = {
 
 export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 	server = new McpServer({
-		name: "Google OAuth Proxy Demo",
-		version: "0.0.1",
+		name: "Google Drive MCP",
+		version: "1.0.0",
 	});
 
 	async init() {
+		// Demo tool - keep for testing
 		this.server.tool("add", { a: z.number(), b: z.number() }, async ({ a, b }) => ({
 			content: [{ text: String(a + b), type: "text" }],
 		}));
+
+		// 1. List files in Drive
+		this.server.tool(
+			"list_files",
+			{
+				folderId: z.string().optional().describe("Folder ID to list files from. If not provided, lists from root or all accessible files."),
+				pageSize: z.number().default(100).describe("Number of files to return (max 1000)"),
+				query: z.string().optional().describe("Google Drive query string (e.g., \"mimeType='image/jpeg'\")"),
+			},
+			async ({ folderId, pageSize, query }) => {
+				let url = `https://www.googleapis.com/drive/v3/files?pageSize=${pageSize}`;
+
+				if (query) {
+					url += `&q=${encodeURIComponent(query)}`;
+				} else if (folderId) {
+					url += `&q=${encodeURIComponent(`'${folderId}' in parents`)}`;
+				}
+
+				url += "&fields=files(id,name,mimeType,size,createdTime,modifiedTime,webViewLink,parents)";
+
+				const response = await fetch(url, {
+					headers: { Authorization: `Bearer ${this.props.accessToken}` },
+				});
+
+				if (!response.ok) {
+					const error = await response.text();
+					return { content: [{ type: "text", text: `Error: ${response.status} - ${error}` }] };
+				}
+
+				const data = await response.json();
+				return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+			},
+		);
+
+		// 2. Search files
+		this.server.tool(
+			"search_files",
+			{
+				query: z.string().describe("Search query using Google Drive query syntax"),
+				pageSize: z.number().default(20).describe("Number of results to return"),
+			},
+			async ({ query, pageSize }) => {
+				const response = await fetch(
+					`https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(query)}&pageSize=${pageSize}&fields=files(id,name,mimeType,webViewLink,modifiedTime)`,
+					{
+						headers: { Authorization: `Bearer ${this.props.accessToken}` },
+					},
+				);
+
+				if (!response.ok) {
+					const error = await response.text();
+					return { content: [{ type: "text", text: `Error: ${response.status} - ${error}` }] };
+				}
+
+				return { content: [{ type: "text", text: JSON.stringify(await response.json(), null, 2) }] };
+			},
+		);
+
+		// 3. Get file content
+		this.server.tool(
+			"get_file_content",
+			{
+				fileId: z.string().describe("The ID of the file to retrieve"),
+				mimeType: z.string().optional().describe("Export MIME type for Google Docs/Sheets/Slides (e.g., 'text/plain', 'application/pdf')"),
+			},
+			async ({ fileId, mimeType }) => {
+				let url = `https://www.googleapis.com/drive/v3/files/${fileId}`;
+
+				// If mimeType is provided, use export endpoint for Google Workspace files
+				if (mimeType) {
+					url = `https://www.googleapis.com/drive/v3/files/${fileId}/export?mimeType=${encodeURIComponent(mimeType)}`;
+				} else {
+					url += "?alt=media";
+				}
+
+				const response = await fetch(url, {
+					headers: { Authorization: `Bearer ${this.props.accessToken}` },
+				});
+
+				if (!response.ok) {
+					const error = await response.text();
+					return { content: [{ type: "text", text: `Error: ${response.status} - ${error}` }] };
+				}
+
+				const content = await response.text();
+				return { content: [{ type: "text", text: content }] };
+			},
+		);
+
+		// 4. Get file metadata
+		this.server.tool(
+			"get_file_metadata",
+			{
+				fileId: z.string().describe("The ID of the file"),
+			},
+			async ({ fileId }) => {
+				const response = await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}?fields=*`, {
+					headers: { Authorization: `Bearer ${this.props.accessToken}` },
+				});
+
+				if (!response.ok) {
+					const error = await response.text();
+					return { content: [{ type: "text", text: `Error: ${response.status} - ${error}` }] };
+				}
+
+				return { content: [{ type: "text", text: JSON.stringify(await response.json(), null, 2) }] };
+			},
+		);
+
+		// 5. Upload file
+		this.server.tool(
+			"upload_file",
+			{
+				name: z.string().describe("Name of the file"),
+				content: z.string().describe("Content of the file"),
+				mimeType: z.string().default("text/plain").describe("MIME type of the file"),
+				folderId: z.string().optional().describe("Parent folder ID"),
+			},
+			async ({ name, content, mimeType, folderId }) => {
+				const metadata = {
+					name,
+					mimeType,
+					...(folderId && { parents: [folderId] }),
+				};
+
+				const boundary = "-------314159265358979323846";
+				const delimiter = "\r\n--" + boundary + "\r\n";
+				const closeDelimiter = "\r\n--" + boundary + "--";
+
+				const multipartRequestBody =
+					delimiter +
+					"Content-Type: application/json\r\n\r\n" +
+					JSON.stringify(metadata) +
+					delimiter +
+					"Content-Type: " +
+					mimeType +
+					"\r\n\r\n" +
+					content +
+					closeDelimiter;
+
+				const response = await fetch("https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart", {
+					method: "POST",
+					headers: {
+						Authorization: `Bearer ${this.props.accessToken}`,
+						"Content-Type": `multipart/related; boundary=${boundary}`,
+					},
+					body: multipartRequestBody,
+				});
+
+				if (!response.ok) {
+					const error = await response.text();
+					return { content: [{ type: "text", text: `Error: ${response.status} - ${error}` }] };
+				}
+
+				return { content: [{ type: "text", text: JSON.stringify(await response.json(), null, 2) }] };
+			},
+		);
+
+		// 6. Create folder
+		this.server.tool(
+			"create_folder",
+			{
+				name: z.string().describe("Name of the folder"),
+				parentId: z.string().optional().describe("Parent folder ID"),
+			},
+			async ({ name, parentId }) => {
+				const metadata = {
+					name,
+					mimeType: "application/vnd.google-apps.folder",
+					...(parentId && { parents: [parentId] }),
+				};
+
+				const response = await fetch("https://www.googleapis.com/drive/v3/files", {
+					method: "POST",
+					headers: {
+						Authorization: `Bearer ${this.props.accessToken}`,
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify(metadata),
+				});
+
+				if (!response.ok) {
+					const error = await response.text();
+					return { content: [{ type: "text", text: `Error: ${response.status} - ${error}` }] };
+				}
+
+				return { content: [{ type: "text", text: JSON.stringify(await response.json(), null, 2) }] };
+			},
+		);
+
+		// 7. Move file
+		this.server.tool(
+			"move_file",
+			{
+				fileId: z.string().describe("ID of the file to move"),
+				newParentId: z.string().describe("ID of the destination folder"),
+				removeParents: z.string().optional().describe("Comma-separated parent IDs to remove"),
+			},
+			async ({ fileId, newParentId, removeParents }) => {
+				let url = `https://www.googleapis.com/drive/v3/files/${fileId}?addParents=${newParentId}`;
+				if (removeParents) {
+					url += `&removeParents=${removeParents}`;
+				}
+
+				const response = await fetch(url, {
+					method: "PATCH",
+					headers: { Authorization: `Bearer ${this.props.accessToken}` },
+				});
+
+				if (!response.ok) {
+					const error = await response.text();
+					return { content: [{ type: "text", text: `Error: ${response.status} - ${error}` }] };
+				}
+
+				return { content: [{ type: "text", text: JSON.stringify(await response.json(), null, 2) }] };
+			},
+		);
+
+		// 8. Rename file
+		this.server.tool(
+			"rename_file",
+			{
+				fileId: z.string().describe("ID of the file to rename"),
+				newName: z.string().describe("New name for the file"),
+			},
+			async ({ fileId, newName }) => {
+				const response = await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}`, {
+					method: "PATCH",
+					headers: {
+						Authorization: `Bearer ${this.props.accessToken}`,
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify({ name: newName }),
+				});
+
+				if (!response.ok) {
+					const error = await response.text();
+					return { content: [{ type: "text", text: `Error: ${response.status} - ${error}` }] };
+				}
+
+				return { content: [{ type: "text", text: JSON.stringify(await response.json(), null, 2) }] };
+			},
+		);
+
+		// 9. Delete file
+		this.server.tool(
+			"delete_file",
+			{
+				fileId: z.string().describe("ID of the file to delete"),
+			},
+			async ({ fileId }) => {
+				const response = await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}`, {
+					method: "DELETE",
+					headers: { Authorization: `Bearer ${this.props.accessToken}` },
+				});
+
+				if (!response.ok) {
+					const error = await response.text();
+					return { content: [{ type: "text", text: `Error: ${response.status} - ${error}` }] };
+				}
+
+				return {
+					content: [
+						{
+							type: "text",
+							text: `File ${fileId} deleted successfully`,
+						},
+					],
+				};
+			},
+		);
+
+		// 10. Share file / Set permissions
+		this.server.tool(
+			"share_file",
+			{
+				fileId: z.string().describe("ID of the file to share"),
+				email: z.string().describe("Email address to share with"),
+				role: z.enum(["reader", "writer", "commenter"]).describe("Permission role"),
+				type: z.enum(["user", "group", "domain", "anyone"]).default("user").describe("Permission type"),
+			},
+			async ({ fileId, email, role, type }) => {
+				const permission = {
+					type,
+					role,
+					emailAddress: email,
+				};
+
+				const response = await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}/permissions`, {
+					method: "POST",
+					headers: {
+						Authorization: `Bearer ${this.props.accessToken}`,
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify(permission),
+				});
+
+				if (!response.ok) {
+					const error = await response.text();
+					return { content: [{ type: "text", text: `Error: ${response.status} - ${error}` }] };
+				}
+
+				return { content: [{ type: "text", text: JSON.stringify(await response.json(), null, 2) }] };
+			},
+		);
 	}
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -319,78 +319,83 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 		);
 
 		// 10. Share file / Set permissions
-		this.server.tool(
-			"share_file",
-			{
+		// Schema with conditional validation using superRefine
+		const shareFileParams = z
+			.object({
 				fileId: z.string().describe("ID of the file to share"),
-				email: z.string().optional().describe("Email address (required for 'user' or 'group' type)"),
-				domain: z.string().optional().describe("Domain name (required for 'domain' type)"),
-				role: z.enum(["reader", "writer", "commenter"]).describe("Permission role"),
 				type: z.enum(["user", "group", "domain", "anyone"]).default("user").describe("Permission type"),
-			},
-			async ({ fileId, email, domain, role, type }) => {
-				// Build type-safe permission object using strict discriminated union
-				let permission: DrivePermission;
-
-				// Handle each type separately for strict type safety
-				if (type === "user") {
-					if (!email) {
-						return {
-							content: [{ type: "text", text: "Error: 'email' parameter is required for type 'user'" }],
-						};
+				role: z.enum(["reader", "writer", "commenter"]).describe("Permission role"),
+				email: z.string().email().optional().describe("Email address (required for 'user' or 'group' type)"),
+				domain: z.string().optional().describe("Domain name (required for 'domain' type)"),
+			})
+			.superRefine((data, ctx) => {
+				// Validate conditional requirements based on type
+				if (data.type === "user" || data.type === "group") {
+					if (!data.email) {
+						ctx.addIssue({
+							code: z.ZodIssueCode.custom,
+							path: ["email"],
+							message: `Email is required when type is '${data.type}'`,
+						});
 					}
-					permission = {
-						type: "user",
-						role,
-						emailAddress: email,
-					};
-				} else if (type === "group") {
-					if (!email) {
-						return {
-							content: [{ type: "text", text: "Error: 'email' parameter is required for type 'group'" }],
-						};
+				} else if (data.type === "domain") {
+					if (!data.domain) {
+						ctx.addIssue({
+							code: z.ZodIssueCode.custom,
+							path: ["domain"],
+							message: "Domain is required when type is 'domain'",
+						});
 					}
-					permission = {
-						type: "group",
-						role,
-						emailAddress: email,
-					};
-				} else if (type === "domain") {
-					if (!domain) {
-						return {
-							content: [{ type: "text", text: "Error: 'domain' parameter is required for type 'domain'" }],
-						};
-					}
-					permission = {
-						type: "domain",
-						role,
-						domain,
-					};
-				} else {
-					// type === "anyone"
-					permission = {
-						type: "anyone",
-						role,
-					};
 				}
+			});
 
-				const response = await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}/permissions`, {
-					method: "POST",
-					headers: {
-						Authorization: `Bearer ${this.props.accessToken}`,
-						"Content-Type": "application/json",
-					},
-					body: JSON.stringify(permission),
-				});
+		this.server.tool("share_file", shareFileParams.shape, async ({ fileId, email, domain, role, type }) => {
+			// Build type-safe permission object using strict discriminated union
+			let permission: DrivePermission;
 
-				if (!response.ok) {
-					const error = await response.text();
-					return { content: [{ type: "text", text: `Error: ${response.status} - ${error}` }] };
-				}
+			// Handle each type separately for strict type safety
+			if (type === "user") {
+				permission = {
+					type: "user",
+					role,
+					emailAddress: email!,  // ! is safe because superRefine validates this
+				};
+			} else if (type === "group") {
+				permission = {
+					type: "group",
+					role,
+					emailAddress: email!,  // ! is safe because superRefine validates this
+				};
+			} else if (type === "domain") {
+				permission = {
+					type: "domain",
+					role,
+					domain: domain!,  // ! is safe because superRefine validates this
+				};
+			} else {
+				// type === "anyone"
+				permission = {
+					type: "anyone",
+					role,
+				};
+			}
 
-				return { content: [{ type: "text", text: JSON.stringify(await response.json(), null, 2) }] };
-			},
-		);
+			const response = await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}/permissions`, {
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${this.props.accessToken}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify(permission),
+			});
+
+			if (!response.ok) {
+				const error = await response.text();
+				return { content: [{ type: "text", text: `Error: ${response.status} - ${error}` }] };
+			}
+
+			return { content: [{ type: "text", text: JSON.stringify(await response.json(), null, 2) }] };
+		});
 	}
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,23 @@ type Props = {
 	accessToken: string;
 };
 
-// Google Drive API Permission types
-// Using strict discriminated union for type safety
+/**
+ * Google Drive API Permission types
+ *
+ * This is a strict discriminated union type that exactly matches Google Drive API's
+ * permission object structure. Each permission type has different required fields:
+ *
+ * - 'user': Requires emailAddress (individual user's email)
+ * - 'group': Requires emailAddress (group's email)
+ * - 'domain': Requires domain (domain name, e.g., "example.com")
+ * - 'anyone': No additional fields needed (public access)
+ *
+ * Using a discriminated union ensures TypeScript enforces correct field usage
+ * at compile time. For example, TypeScript will prevent adding 'emailAddress'
+ * to an 'anyone' permission, or adding 'domain' to a 'user' permission.
+ *
+ * Reference: https://developers.google.com/drive/api/reference/rest/v3/permissions
+ */
 type DrivePermission =
 	| {
 			type: "user";
@@ -319,83 +334,119 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 		);
 
 		// 10. Share file / Set permissions
-		// Schema with conditional validation using superRefine
-		const shareFileParams = z
-			.object({
+		/**
+		 * NOTE: Why we use optional fields + manual validation instead of Zod refinements:
+		 *
+		 * The MCP SDK internally wraps the schema with z.object() (see mcp.js:_createRegisteredTool),
+		 * which means:
+		 * - Cannot use z.discriminatedUnion() - SDK expects ZodRawShape, not ZodUnion
+		 * - Cannot use .superRefine() - SDK wraps the schema, losing refinement logic
+		 * - Cannot pass ZodObject directly - SDK only accepts { key: ZodType } shape
+		 *
+		 * Therefore, we must:
+		 * 1. Define fields as optional in the schema
+		 * 2. Manually validate conditional requirements in the callback
+		 * 3. Return clear error messages for validation failures
+		 *
+		 * This is the correct approach per MCP SDK's API design.
+		 */
+		this.server.tool(
+			"share_file",
+			{
 				fileId: z.string().describe("ID of the file to share"),
 				type: z.enum(["user", "group", "domain", "anyone"]).default("user").describe("Permission type"),
 				role: z.enum(["reader", "writer", "commenter"]).describe("Permission role"),
-				email: z.string().email().optional().describe("Email address (required for 'user' or 'group' type)"),
-				domain: z.string().optional().describe("Domain name (required for 'domain' type)"),
-			})
-			.superRefine((data, ctx) => {
-				// Validate conditional requirements based on type
-				if (data.type === "user" || data.type === "group") {
-					if (!data.email) {
-						ctx.addIssue({
-							code: z.ZodIssueCode.custom,
-							path: ["email"],
-							message: `Email is required when type is '${data.type}'`,
-						});
+				email: z
+					.string()
+					.email()
+					.optional()
+					.describe("Email address (required when type is 'user' or 'group')"),
+				domain: z.string().optional().describe("Domain name (required when type is 'domain')"),
+			},
+			async ({ fileId, email, domain, role, type }) => {
+				// Build type-safe permission object following Google Drive API requirements
+				// Reference: https://developers.google.com/drive/api/reference/rest/v3/permissions
+				let permission: DrivePermission;
+
+				// Validate and construct permission based on type
+				// Each type has different required fields per Google Drive API spec
+				if (type === "user") {
+					// User permissions require an email address
+					if (!email) {
+						return {
+							content: [
+								{
+									type: "text",
+									text: "Error: 'email' parameter is required when type is 'user'",
+								},
+							],
+						};
 					}
-				} else if (data.type === "domain") {
-					if (!data.domain) {
-						ctx.addIssue({
-							code: z.ZodIssueCode.custom,
-							path: ["domain"],
-							message: "Domain is required when type is 'domain'",
-						});
+					permission = {
+						type: "user",
+						role,
+						emailAddress: email,
+					};
+				} else if (type === "group") {
+					// Group permissions require an email address
+					if (!email) {
+						return {
+							content: [
+								{
+									type: "text",
+									text: "Error: 'email' parameter is required when type is 'group'",
+								},
+							],
+						};
 					}
+					permission = {
+						type: "group",
+						role,
+						emailAddress: email,
+					};
+				} else if (type === "domain") {
+					// Domain permissions require a domain name
+					if (!domain) {
+						return {
+							content: [
+								{
+									type: "text",
+									text: "Error: 'domain' parameter is required when type is 'domain'",
+								},
+							],
+						};
+					}
+					permission = {
+						type: "domain",
+						role,
+						domain,
+					};
+				} else {
+					// Anyone permissions don't require additional fields
+					permission = {
+						type: "anyone",
+						role,
+					};
 				}
-			});
 
-		this.server.tool("share_file", shareFileParams.shape, async ({ fileId, email, domain, role, type }) => {
-			// Build type-safe permission object using strict discriminated union
-			let permission: DrivePermission;
+				// Send permission request to Google Drive API
+				const response = await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}/permissions`, {
+					method: "POST",
+					headers: {
+						Authorization: `Bearer ${this.props.accessToken}`,
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify(permission),
+				});
 
-			// Handle each type separately for strict type safety
-			if (type === "user") {
-				permission = {
-					type: "user",
-					role,
-					emailAddress: email!,  // ! is safe because superRefine validates this
-				};
-			} else if (type === "group") {
-				permission = {
-					type: "group",
-					role,
-					emailAddress: email!,  // ! is safe because superRefine validates this
-				};
-			} else if (type === "domain") {
-				permission = {
-					type: "domain",
-					role,
-					domain: domain!,  // ! is safe because superRefine validates this
-				};
-			} else {
-				// type === "anyone"
-				permission = {
-					type: "anyone",
-					role,
-				};
-			}
+				if (!response.ok) {
+					const error = await response.text();
+					return { content: [{ type: "text", text: `Error: ${response.status} - ${error}` }] };
+				}
 
-			const response = await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}/permissions`, {
-				method: "POST",
-				headers: {
-					Authorization: `Bearer ${this.props.accessToken}`,
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify(permission),
-			});
-
-			if (!response.ok) {
-				const error = await response.text();
-				return { content: [{ type: "text", text: `Error: ${response.status} - ${error}` }] };
-			}
-
-			return { content: [{ type: "text", text: JSON.stringify(await response.json(), null, 2) }] };
-		});
+				return { content: [{ type: "text", text: JSON.stringify(await response.json(), null, 2) }] };
+			},
+		);
 	}
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,16 +300,45 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 			"share_file",
 			{
 				fileId: z.string().describe("ID of the file to share"),
-				email: z.string().describe("Email address to share with"),
+				email: z.string().optional().describe("Email address (required for 'user' or 'group' type)"),
+				domain: z.string().optional().describe("Domain name (required for 'domain' type)"),
 				role: z.enum(["reader", "writer", "commenter"]).describe("Permission role"),
 				type: z.enum(["user", "group", "domain", "anyone"]).default("user").describe("Permission type"),
 			},
-			async ({ fileId, email, role, type }) => {
-				const permission = {
+			async ({ fileId, email, domain, role, type }) => {
+				// Build permission object based on type
+				const permission: any = {
 					type,
 					role,
-					emailAddress: email,
 				};
+
+				// Add type-specific fields
+				if (type === "user" || type === "group") {
+					if (!email) {
+						return {
+							content: [
+								{
+									type: "text",
+									text: `Error: 'email' parameter is required for type '${type}'`,
+								},
+							],
+						};
+					}
+					permission.emailAddress = email;
+				} else if (type === "domain") {
+					if (!domain) {
+						return {
+							content: [
+								{
+									type: "text",
+									text: "Error: 'domain' parameter is required for type 'domain'",
+								},
+							],
+						};
+					}
+					permission.domain = domain;
+				}
+				// For type 'anyone', no additional fields needed
 
 				const response = await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}/permissions`, {
 					method: "POST",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add a full Google Drive toolset to the MCP server and expand Google OAuth scope to include Drive access.
> 
> - **Google OAuth**:
>   - Expand `scope` in `src/google-handler.ts` to include `https://www.googleapis.com/auth/drive`.
> - **MCP Server (Drive integration)**:
>   - Rename server to `"Google Drive MCP"` and bump version to `1.0.0` in `src/index.ts`.
>   - Add Drive permission type union `DrivePermission`.
>   - Add tools (all use `this.props.accessToken`):
>     - `list_files`, `search_files` for querying files.
>     - `get_file_content`, `get_file_metadata` for retrieval.
>     - `upload_file`, `create_folder` for creation.
>     - `move_file`, `rename_file`, `delete_file` for modifications.
>     - `share_file` to set permissions with manual validation of `user/group/domain/anyone` cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 568a2712b4d3fb117e066c3df7cf2cc76e102607. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->