### PR TITLE
Remove deprecated demo tool and complex file sharing implementation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,44 +12,6 @@ type Props = {
 	accessToken: string;
 };
 
-/**
- * Google Drive API Permission types
- *
- * This is a strict discriminated union type that exactly matches Google Drive API's
- * permission object structure. Each permission type has different required fields:
- *
- * - 'user': Requires emailAddress (individual user's email)
- * - 'group': Requires emailAddress (group's email)
- * - 'domain': Requires domain (domain name, e.g., "example.com")
- * - 'anyone': No additional fields needed (public access)
- *
- * Using a discriminated union ensures TypeScript enforces correct field usage
- * at compile time. For example, TypeScript will prevent adding 'emailAddress'
- * to an 'anyone' permission, or adding 'domain' to a 'user' permission.
- *
- * Reference: https://developers.google.com/drive/api/reference/rest/v3/permissions
- */
-type DrivePermission =
-	| {
-			type: "user";
-			role: "reader" | "writer" | "commenter";
-			emailAddress: string;
-	  }
-	| {
-			type: "group";
-			role: "reader" | "writer" | "commenter";
-			emailAddress: string;
-	  }
-	| {
-			type: "domain";
-			role: "reader" | "writer" | "commenter";
-			domain: string;
-	  }
-	| {
-			type: "anyone";
-			role: "reader" | "writer" | "commenter";
-	  };
-
 export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 	server = new McpServer({
 		name: "Google Drive MCP",
@@ -57,11 +19,6 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 	});
 
 	async init() {
-		// Demo tool - keep for testing
-		this.server.tool("add", { a: z.number(), b: z.number() }, async ({ a, b }) => ({
-			content: [{ text: String(a + b), type: "text" }],
-		}));
-
 		// 1. List files in Drive
 		this.server.tool(
 			"list_files",
@@ -333,120 +290,6 @@ export class MyMCP extends McpAgent<Env, Record<string, never>, Props> {
 			},
 		);
 
-		// 10. Share file / Set permissions
-		/**
-		 * NOTE: Why we use optional fields + manual validation instead of Zod refinements:
-		 *
-		 * The MCP SDK internally wraps the schema with z.object() (see mcp.js:_createRegisteredTool),
-		 * which means:
-		 * - Cannot use z.discriminatedUnion() - SDK expects ZodRawShape, not ZodUnion
-		 * - Cannot use .superRefine() - SDK wraps the schema, losing refinement logic
-		 * - Cannot pass ZodObject directly - SDK only accepts { key: ZodType } shape
-		 *
-		 * Therefore, we must:
-		 * 1. Define fields as optional in the schema
-		 * 2. Manually validate conditional requirements in the callback
-		 * 3. Return clear error messages for validation failures
-		 *
-		 * This is the correct approach per MCP SDK's API design.
-		 */
-		this.server.tool(
-			"share_file",
-			{
-				fileId: z.string().describe("ID of the file to share"),
-				type: z.enum(["user", "group", "domain", "anyone"]).default("user").describe("Permission type"),
-				role: z.enum(["reader", "writer", "commenter"]).describe("Permission role"),
-				email: z
-					.string()
-					.email()
-					.optional()
-					.describe("Email address (required when type is 'user' or 'group')"),
-				domain: z.string().optional().describe("Domain name (required when type is 'domain')"),
-			},
-			async ({ fileId, email, domain, role, type }) => {
-				// Build type-safe permission object following Google Drive API requirements
-				// Reference: https://developers.google.com/drive/api/reference/rest/v3/permissions
-				let permission: DrivePermission;
-
-				// Validate and construct permission based on type
-				// Each type has different required fields per Google Drive API spec
-				if (type === "user") {
-					// User permissions require an email address
-					if (!email) {
-						return {
-							content: [
-								{
-									type: "text",
-									text: "Error: 'email' parameter is required when type is 'user'",
-								},
-							],
-						};
-					}
-					permission = {
-						type: "user",
-						role,
-						emailAddress: email,
-					};
-				} else if (type === "group") {
-					// Group permissions require an email address
-					if (!email) {
-						return {
-							content: [
-								{
-									type: "text",
-									text: "Error: 'email' parameter is required when type is 'group'",
-								},
-							],
-						};
-					}
-					permission = {
-						type: "group",
-						role,
-						emailAddress: email,
-					};
-				} else if (type === "domain") {
-					// Domain permissions require a domain name
-					if (!domain) {
-						return {
-							content: [
-								{
-									type: "text",
-									text: "Error: 'domain' parameter is required when type is 'domain'",
-								},
-							],
-						};
-					}
-					permission = {
-						type: "domain",
-						role,
-						domain,
-					};
-				} else {
-					// Anyone permissions don't require additional fields
-					permission = {
-						type: "anyone",
-						role,
-					};
-				}
-
-				// Send permission request to Google Drive API
-				const response = await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}/permissions`, {
-					method: "POST",
-					headers: {
-						Authorization: `Bearer ${this.props.accessToken}`,
-						"Content-Type": "application/json",
-					},
-					body: JSON.stringify(permission),
-				});
-
-				if (!response.ok) {
-					const error = await response.text();
-					return { content: [{ type: "text", text: `Error: ${response.status} - ${error}` }] };
-				}
-
-				return { content: [{ type: "text", text: JSON.stringify(await response.json(), null, 2) }] };
-			},
-		);
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the demo `add` tool and the `share_file` permissions implementation (including `DrivePermission` type), keeping only core Drive file operations.
> 
> - **MCP Server (`src/index.ts`)**:
>   - **Removed**:
>     - Demo tool `add`.
>     - `share_file` tool and all Google Drive permission handling/validation.
>     - `DrivePermission` type and related documentation.
>   - **Unchanged**: Core file operations (`list_files`, `search_files`, `get_file_content`, `get_file_metadata`, `upload_file`, `create_folder`, `move_file`, `rename_file`, `delete_file`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2c92886af72fe94831afc4a538f91addb9860ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->